### PR TITLE
Forward env to updatedb

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -438,7 +438,10 @@ module.exports = {
 		if(typeof license_key === 'function'){
 			callback = license_key
 		} else {
-			options.env = {GEOLITE2_LICENSE_KEY: license_key}
+			options.env = {
+				...process.env,
+				GEOLITE2_LICENSE_KEY: license_key,
+			}
 		}
 		if(!callback){
 			callback = function(){}


### PR DESCRIPTION
We found when no `env` is passed to exec, the scripts works as expected, but when overriding it do also for other needed environment variables such as `PATH` and throws an error of being able to found some tools.