### PR TITLE
Add clean exit on Success

### DIFF
--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -601,5 +601,6 @@ async.eachSeries(databases, function(database, nextDatabase) {
 		console.log('Successfully Updated Databases from MaxMind.');
 		if (process.argv[2] == 'debug') console.log('Notice: temporary files are not deleted for debug purposes.'.bold.yellow);
 		else setTimeout(function(){rimraf(tmpPath);}, 100);
+		process.exit(0);
 	}
 });


### PR DESCRIPTION
See issue #27 
I had to add a clean exit after success because the process hangs.

Update - this only happens for me in Node 20
Node 12 works fine - I suspect setTimeout